### PR TITLE
fix minor issues with `lm_decomposition.py` pipeline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Sparse Parameter Decomposition"
 requires-python = ">=3.11"
 readme = "README.md"
 dependencies = [
-    "torch<2.6.0",
+    "torch>2.4.1,<2.6.0",
     "torchvision",
     "pydantic",
     "wandb",

--- a/spd/experiments/lm/lm_decomposition.py
+++ b/spd/experiments/lm/lm_decomposition.py
@@ -49,7 +49,11 @@ def plot_lm_results(
 
 
 def main(
-    config_path_or_obj: Path | str | Config, sweep_config_path: Path | str | None = None
+    config_path_or_obj: Path | str | Config,
+    sweep_config_path: Path | str | None = None,
+    # due to pytorch vuln https://nvd.nist.gov/vuln/detail/CVE-2025-32434
+    # hf `transformers` library doesn't allow loading with weights_only=True
+    weights_only: bool = True,
 ) -> None:
     config = load_config(config_path_or_obj, config_model=Config)
 
@@ -72,6 +76,7 @@ def main(
         path_to_class=config.pretrained_model_class,
         model_path=None,
         model_name_hf=config.pretrained_model_name_hf,
+        weights_only=weights_only,
     )
 
     # --- Setup Run Name and Output Dir --- #


### PR DESCRIPTION
## Description

1. bump torch dependency to require `>2.4.1`
2. add `weights_only: bool` kwarg to `lm_decomposition.py:main()`

## Motivation and Context

1. because pytorch `<=2.4.1` does not have `nn.Module.set_submodule()`, running `lm_decomposition.py` gives the error:

```
  File "~/apd/spd/experiments/lm/lm_decomposition.py", line 146, in main
    optimize(
  File "/home/miv/projects/MATS/apd/spd/run_spd.py", line 242, in optimize
    layerwise_random_recon_loss = calc_layerwise_recon_loss(
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/apd/spd/losses.py", line 135, in calc_layerwise_recon_loss
    modified_out = model.forward_with_component(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/apd/spd/models/component_model.py", line 141, in forward_with_component
    self.model.set_submodule(module_name, component)
    ^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/apd/.venv/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1729, in __getattr__
    raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
AttributeError: 'GPTNeoForCausalLM' object has no attribute 'set_submodule'
```

2. due to pytorch vuln https://nvd.nist.gov/vuln/detail/CVE-2025-32434 huggingface transformers library doesn't allow loading with `weights_only=True`, adding a kwarg for this in  `lm_decomposition.py:main()` which is passed on to `load_pretrained()`


## Does this PR introduce a breaking change?

Probably not. Most likely to cause issues is the bumping of the pytorch dep.